### PR TITLE
Fade out and hide the table view cell, instead of changing its background color

### DIFF
--- a/UDo.xcodeproj/project.pbxproj
+++ b/UDo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6190AF3F199659AE00E12D44 /* RWBasicTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 6190AF3E199659AE00E12D44 /* RWBasicTableViewCell.m */; };
 		6D3189C0187C422A00994DDF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6D3189BF187C422A00994DDF /* Foundation.framework */; };
 		6D3189C2187C422A00994DDF /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6D3189C1187C422A00994DDF /* CoreGraphics.framework */; };
 		6D3189C4187C422A00994DDF /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6D3189C3187C422A00994DDF /* UIKit.framework */; };
@@ -35,6 +36,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		6190AF3D199659AE00E12D44 /* RWBasicTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RWBasicTableViewCell.h; sourceTree = "<group>"; };
+		6190AF3E199659AE00E12D44 /* RWBasicTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RWBasicTableViewCell.m; sourceTree = "<group>"; };
 		6D3189BC187C422A00994DDF /* UDo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = UDo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6D3189BF187C422A00994DDF /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		6D3189C1187C422A00994DDF /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -120,6 +123,8 @@
 				6D3189CF187C422A00994DDF /* RWAppDelegate.m */,
 				6D3189EF187C427400994DDF /* RWTableViewController.h */,
 				6D3189F0187C427400994DDF /* RWTableViewController.m */,
+				6190AF3D199659AE00E12D44 /* RWBasicTableViewCell.h */,
+				6190AF3E199659AE00E12D44 /* RWBasicTableViewCell.m */,
 				6D3189F6187C438B00994DDF /* UIAlertView+RWBlock.h */,
 				6D3189F7187C438B00994DDF /* UIAlertView+RWBlock.m */,
 				6D3189F2187C42A800994DDF /* Images.xcassets */,
@@ -260,6 +265,7 @@
 				6D3189F8187C438B00994DDF /* UIAlertView+RWBlock.m in Sources */,
 				6D3189CC187C422A00994DDF /* main.m in Sources */,
 				6D3189F1187C427400994DDF /* RWTableViewController.m in Sources */,
+				6190AF3F199659AE00E12D44 /* RWBasicTableViewCell.m in Sources */,
 				6D3189D0187C422A00994DDF /* RWAppDelegate.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/UDo/RWBasicTableViewCell.h
+++ b/UDo/RWBasicTableViewCell.h
@@ -1,0 +1,15 @@
+//
+//  RWBasicTableViewCell.h
+//  UDo
+//
+//  Created by Soheil M. Azarpour on 8/9/14.
+//  Copyright (c) 2014 Soheil Azarpour. All rights reserved.
+//
+
+@import UIKit;
+
+@interface RWBasicTableViewCell : UITableViewCell
+
+@property (weak, nonatomic) IBOutlet UILabel *titleLabel;
+
+@end

--- a/UDo/RWBasicTableViewCell.m
+++ b/UDo/RWBasicTableViewCell.m
@@ -1,0 +1,13 @@
+//
+//  RWBasicTableViewCell.m
+//  UDo
+//
+//  Created by Soheil M. Azarpour on 8/9/14.
+//  Copyright (c) 2014 Soheil Azarpour. All rights reserved.
+//
+
+#import "RWBasicTableViewCell.h"
+
+@implementation RWBasicTableViewCell
+
+@end

--- a/UDo/RWTableViewController.m
+++ b/UDo/RWTableViewController.m
@@ -7,6 +7,7 @@
 //
 
 #import "RWTableViewController.h"
+#import "RWBasicTableViewCell.h"
 #import "UIAlertView+RWBlock.h"
 
 @interface RWTableViewController ()
@@ -47,12 +48,11 @@
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
   static NSString *kIdentifier = @"Cell Identifier";
   
-  UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:kIdentifier forIndexPath:indexPath];
+  RWBasicTableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:kIdentifier forIndexPath:indexPath];
   
   // Update cell content from data source.
   NSString *object = self.objects[indexPath.row];
-  cell.backgroundColor = [UIColor whiteColor];
-  cell.textLabel.text = object;
+  cell.titleLabel.text = object;
   
   return cell;
 }
@@ -133,10 +133,13 @@
           snapshot.center = center;
           snapshot.transform = CGAffineTransformMakeScale(1.05, 1.05);
           snapshot.alpha = 0.98;
+          cell.alpha = 0.0;
           
-          // Black out.
-          cell.backgroundColor = [UIColor blackColor];
-        } completion:nil];
+        } completion:^(BOOL finished) {
+          
+          cell.hidden = YES;
+          
+        }];
       }
       break;
     }
@@ -164,22 +167,24 @@
     default: {
       // Clean up.
       UITableViewCell *cell = [self.tableView cellForRowAtIndexPath:sourceIndexPath];
+      cell.hidden = NO;
+      cell.alpha = 0.0;
+      
       [UIView animateWithDuration:0.25 animations:^{
         
         snapshot.center = cell.center;
         snapshot.transform = CGAffineTransformIdentity;
         snapshot.alpha = 0.0;
-        
-        // Undo the black-out effect we did.
-        cell.backgroundColor = [UIColor whiteColor];
+        cell.alpha = 1.0;
         
       } completion:^(BOOL finished) {
         
+        sourceIndexPath = nil;
         [snapshot removeFromSuperview];
         snapshot = nil;
         
       }];
-      sourceIndexPath = nil;
+      
       break;
     }
   }

--- a/UDo/Storyboard.storyboard
+++ b/UDo/Storyboard.storyboard
@@ -1,34 +1,63 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="4514" systemVersion="13B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="2HI-1E-ew3">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="5056" systemVersion="13E28" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="2HI-1E-ew3">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3747"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3733"/>
     </dependencies>
     <scenes>
         <!--Table View Controller-->
         <scene sceneID="aHY-G2-1n7">
             <objects>
                 <tableViewController id="z3Q-Gb-5xD" customClass="RWTableViewController" sceneMemberID="viewController">
-                    <tableView key="view" opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" rowHeight="60" sectionHeaderHeight="22" sectionFooterHeight="22" id="aLn-yv-2Fp">
+                    <tableView key="view" opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="60" sectionHeaderHeight="22" sectionFooterHeight="22" id="aLn-yv-2Fp">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                        <label key="tableFooterView" opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="320" id="sfg-7O-jh0">
+                            <rect key="frame" x="0.0" y="146" width="320" height="60"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <string key="text">www.raywenderlich.com
+Tutorials for Developers &amp; Gamers</string>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                            <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                            <nil key="highlightedColor"/>
+                        </label>
                         <prototypes>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="Cell Identifier" textLabel="bOj-BX-yhD" rowHeight="60" style="IBUITableViewCellStyleDefault" id="2Qv-0X-9Yt">
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="Cell Identifier" rowHeight="60" id="2Qv-0X-9Yt" customClass="RWBasicTableViewCell">
                                 <rect key="frame" x="0.0" y="86" width="320" height="60"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="2Qv-0X-9Yt" id="HYC-jO-wgk">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="59"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="60"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" text="Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="bOj-BX-yhD">
-                                            <rect key="frame" x="15" y="0.0" width="290" height="59"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Km4-E0-oA9" userLabel="Separator Line View">
+                                            <rect key="frame" x="0.0" y="59" width="320" height="1"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            <color key="backgroundColor" white="0.93000000000000005" alpha="1" colorSpace="calibratedWhite"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="1" id="cp3-3E-4LY"/>
+                                            </constraints>
+                                        </view>
+                                        <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kb0-I6-VYM" userLabel="Text Label">
+                                            <rect key="frame" x="20" y="13" width="280" height="33"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
+                                    <constraints>
+                                        <constraint firstAttribute="bottom" secondItem="Km4-E0-oA9" secondAttribute="bottom" id="7De-if-aWf"/>
+                                        <constraint firstItem="Kb0-I6-VYM" firstAttribute="leading" secondItem="HYC-jO-wgk" secondAttribute="leading" constant="20" id="FNV-sf-dTh"/>
+                                        <constraint firstAttribute="trailing" secondItem="Kb0-I6-VYM" secondAttribute="trailing" constant="20" id="Fl5-9B-9Qg"/>
+                                        <constraint firstItem="Km4-E0-oA9" firstAttribute="top" secondItem="Kb0-I6-VYM" secondAttribute="bottom" constant="13" id="St0-eS-AJA"/>
+                                        <constraint firstItem="Km4-E0-oA9" firstAttribute="leading" secondItem="HYC-jO-wgk" secondAttribute="leading" id="s8y-rt-pPf"/>
+                                        <constraint firstAttribute="trailing" secondItem="Km4-E0-oA9" secondAttribute="trailing" id="vxO-of-vfE"/>
+                                        <constraint firstItem="Kb0-I6-VYM" firstAttribute="top" secondItem="HYC-jO-wgk" secondAttribute="top" constant="13" id="zZo-Hg-VdZ"/>
+                                    </constraints>
                                 </tableViewCellContentView>
+                                <connections>
+                                    <outlet property="titleLabel" destination="Kb0-I6-VYM" id="FdQ-pe-l9m"/>
+                                </connections>
                             </tableViewCell>
                         </prototypes>
                         <connections>


### PR DESCRIPTION
This pull request changes the black out effect to fade out effect, as suggested by [@FreddyF](http://www.raywenderlich.com/u/FreddyF), [@ccuenca24@gmail.com](http://www.raywenderlich.com/u/ccuenca24@gmail.com) and others in the [forum](http://www.raywenderlich.com/forums/viewtopic.php?f=20&t=11280). Fade-out gives a smoother animation and has the benefit of showing the background of table view. [Tutorial](http://www.raywenderlich.com/63089/cookbook-moving-table-view-cells-with-a-long-press-gesture) updated accordingly.

_Note_: Some other changes are made too to make the animation look smoother and better. The table view cell is replaced with a custom table view cell; table view background has changed.
